### PR TITLE
Add multi-language translation support with Brazilian Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <h5 align="center">
-  This repository offers an WebUI and API endpoint that translates English PDF files into Japanese, preserving the original layout.
+  This repository offers a WebUI and API endpoint that translates English PDF files into Japanese and Brazilian Portuguese while preserving the original layout.
 </h5>
 
 <p align="center">
@@ -14,7 +14,8 @@
 
 ## Features
 
-To be more readable, the translated PDF file displays the original PDF page in the left side and the translated text in the right side (see the image above).
+- **Multi-language output**: translate English PDFs into Japanese or Brazilian Portuguese with a single command or through the WebUI.
+- To be more readable, the translated PDF file displays the original PDF page in the left side and the translated text in the right side (see the image above).
 
 To speed up the translation process, **translation is performed until "References" section in the PDF file**. After that, the rest of the page is copied as it is.
 
@@ -52,12 +53,14 @@ http://localhost:8288
 ## CLI Usage
 
 ```bash
-cd pdf-translator/docker && make translate INPUT="path/to/input_pdf_or_dir"
+cd pdf-translator/docker && make translate INPUT="path/to/input_pdf_or_dir" LANG="pt-br"
 ```
 
-You can throw a PDF file or a directory containing PDF files.
+You can translate a single PDF file or a directory containing PDF files.
 
-The translated PDF files will be saved in `./outputs` directory.
+- Use `LANG="ja"` for Japanese (default) or `LANG="pt-br"` for Brazilian Portuguese.
+- The translated PDF files will be saved in the `./outputs` directory.
+- Alternatively, call the CLI directly: `python cli.py -i path/to/file.pdf -l pt-br`.
 
 ## Requirements
 
@@ -79,6 +82,8 @@ This repository is licensed under CC BY-NC 4.0. See [LICENSE](./LICENSE.md) for 
 - For text translation, using [FuguMT](https://huggingface.co/staka/fugumt-en-ja) model from [HuggingFace](https://huggingface.co/).
 
   FuguMT models are distributed under the CC BY-SA 4.0 license. Please also note that the use is clearly stated as "for research purposes only" and that "no responsibility is assumed for operation or output".
+
+- For English to Brazilian Portuguese, using the [Helsinki-NLP/opus-mt-en-pt](https://huggingface.co/Helsinki-NLP/opus-mt-en-pt) model from Hugging Face.
 
 - Font files are from [Source Han Serif](https://github.com/adobe-fonts/source-han-serif).
 

--- a/cli.py
+++ b/cli.py
@@ -46,13 +46,17 @@ def translate_request(
             data={"target_language": target_language},
         )
 
-    if response.status_code == 200:
-        with open(output_dir / input_pdf_path.name, "wb") as output_pdf:
-            output_pdf.write(response.content)
-        print(f"Converted PDF saved to {output_dir / input_pdf_path.name}")
-        requests.get(CLEAR_TEMP_URL)
-    else:
-        print(f"An error occurred: {response.status_code}")
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        raise RuntimeError(
+            "Translation request failed"
+        ) from exc
+
+    with open(output_dir / input_pdf_path.name, "wb") as output_pdf:
+        output_pdf.write(response.content)
+    print(f"Converted PDF saved to {output_dir / input_pdf_path.name}")
+    requests.get(CLEAR_TEMP_URL)
 
 
 def main(args: argparse.Namespace) -> None:
@@ -89,7 +93,7 @@ def main(args: argparse.Namespace) -> None:
             args.input_pdf_path_or_dir, args.output_dir, args.target_language
         )
     elif args.input_pdf_path_or_dir.is_dir():
-        input_pdf_paths = args.input_pdf_path_or_dir.glob("*.pdf")
+        input_pdf_paths = list(args.input_pdf_path_or_dir.glob("*.pdf"))
 
         if not input_pdf_paths:
             raise ValueError(f"Input directory is empty: {args.input_pdf_path_or_dir}")

--- a/cli.py
+++ b/cli.py
@@ -4,11 +4,29 @@ from pathlib import Path
 
 import requests
 
+from utils.languages import (
+    DEFAULT_LANGUAGE_CODE,
+    language_help_text,
+    normalize_language_code,
+    supported_language_codes,
+)
+
 TRANSLATE_URL = "http://localhost:8765/translate_pdf/"
 CLEAR_TEMP_URL = "http://localhost:8765/clear_temp_dir/"
 
 
-def translate_request(input_pdf_path: Path, output_dir: Path) -> None:
+def _prepare_language(language_code: str) -> str:
+    """Normalize and validate a target language code."""
+
+    try:
+        return normalize_language_code(language_code)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def translate_request(
+    input_pdf_path: Path, output_dir: Path, target_language: str
+) -> None:
     """Sends a POST request to the translator server to translate a PDF.
 
     Parameters
@@ -17,10 +35,16 @@ def translate_request(input_pdf_path: Path, output_dir: Path) -> None:
         Path to the PDF to be translated.
     output_dir : Path
         Path to the directory where the translated PDF will be saved.
+    target_language : str
+        Target language code for the translation.
     """
     print(f"Translating {input_pdf_path}...")
     with open(input_pdf_path, "rb") as input_pdf:
-        response = requests.post(TRANSLATE_URL, files={"input_pdf": input_pdf})
+        response = requests.post(
+            TRANSLATE_URL,
+            files={"input_pdf": input_pdf},
+            data={"target_language": target_language},
+        )
 
     if response.status_code == 200:
         with open(output_dir / input_pdf_path.name, "wb") as output_pdf:
@@ -61,7 +85,9 @@ def main(args: argparse.Namespace) -> None:
                 f"Input file must be a PDF or directory: {args.input_pdf_path_or_dir}"
             )
 
-        translate_request(args.input_pdf_path_or_dir, args.output_dir)
+        translate_request(
+            args.input_pdf_path_or_dir, args.output_dir, args.target_language
+        )
     elif args.input_pdf_path_or_dir.is_dir():
         input_pdf_paths = args.input_pdf_path_or_dir.glob("*.pdf")
 
@@ -69,7 +95,7 @@ def main(args: argparse.Namespace) -> None:
             raise ValueError(f"Input directory is empty: {args.input_pdf_path_or_dir}")
 
         for input_pdf_path in input_pdf_paths:
-            translate_request(input_pdf_path, args.output_dir)
+            translate_request(input_pdf_path, args.output_dir, args.target_language)
     else:
         raise ValueError(
             f"Input path must be a file or directory: {args.input_pdf_path_or_dir}"
@@ -93,6 +119,17 @@ if __name__ == "__main__":
         type=Path,
         default="./outputs",
         help="Path to the directory where the translated PDFs will be saved. (default: ./outputs)",
+    )
+    parser.add_argument(
+        "-l",
+        "--target_language",
+        type=_prepare_language,
+        default=DEFAULT_LANGUAGE_CODE,
+        choices=list(supported_language_codes()),
+        help=(
+            "Target language code for the translation. Supported values: "
+            f"{language_help_text()} (default: {DEFAULT_LANGUAGE_CODE})."
+        ),
     )
     args = parser.parse_args()
     main(args)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,7 @@
 NAME=pdf-translator
 TAG=0.1.0
 PROJECT_DIRECTORY=$(shell pwd)/..
+LANG?=ja
 
 build:
 	docker build -t ${NAME}:${TAG} .
@@ -28,5 +29,5 @@ run-bash:
 		${NAME}:${TAG} /bin/bash
 
 translate:
-	@cd ${PROJECT_DIRECTORY} && \
-		python3 cli.py -i ${INPUT}
+        @cd ${PROJECT_DIRECTORY} && \
+                python3 cli.py -i ${INPUT} -l ${LANG}

--- a/gui.py
+++ b/gui.py
@@ -20,51 +20,49 @@ DEFAULT_LANGUAGE_LABEL = next(
     label for label, code in LANGUAGE_OPTIONS.items() if code == DEFAULT_LANGUAGE_CODE
 )
 
+def _build_translate_request(
+    temp_dir_path: Path,
+) -> Any:
+    """Create a translate handler bound to a temporary directory."""
 
-def translate_request(file: Any, language_label: str) -> tuple[Path, list[Image.Image]]:
-    """Sends a POST request to the translator server to translate a PDF.
+    def translate_request(
+        file: Any, language_label: str
+    ) -> tuple[str, list[Image.Image]]:
+        """Send a POST request to the translator server to translate a PDF."""
 
-    Parameters
-    ----------
-    file : Any
-        the PDF to be translated.
-    language_label : str
-        Human-readable label of the selected target language.
+        if file is None:
+            raise ValueError("No PDF uploaded.")
 
-    Returns
-    -------
-    tuple[Path, list[Image.Image]]
-        Path to the translated PDF and a list of images of the
-        translated PDF.
-    """
-    if file is None:
-        raise ValueError("No PDF uploaded.")
+        if language_label not in LANGUAGE_OPTIONS:
+            raise ValueError("Unsupported language selection.")
 
-    if language_label not in LANGUAGE_OPTIONS:
-        raise ValueError("Unsupported language selection.")
+        with open(file.name, "rb") as input_pdf:
+            response = requests.post(
+                TRANSLATE_URL,
+                files={"input_pdf": input_pdf},
+                data={"target_language": LANGUAGE_OPTIONS[language_label]},
+            )
 
-    with open(file.name, "rb") as input_pdf:
-        response = requests.post(
-            TRANSLATE_URL,
-            files={"input_pdf": input_pdf},
-            data={"target_language": LANGUAGE_OPTIONS[language_label]},
-        )
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            raise RuntimeError("Translation request failed") from exc
 
-    if response.status_code == 200:
-        with open(Path(temp_dir) / "translated.pdf", "wb") as f:
-            f.write(response.content)
+        output_path = temp_dir_path / "translated.pdf"
+        with open(output_path, "wb") as translated_pdf:
+            translated_pdf.write(response.content)
 
-        images = convert_from_path(Path(temp_dir) / "translated.pdf")
+        images = convert_from_path(output_path)
 
         requests.get(CLEAR_TEMP_URL)
-        return str(Path(temp_dir) / "translated.pdf"), images
-    else:
-        print(f"An error occurred: {response.status_code}")
+        return str(output_path), images
+
+    return translate_request
 
 
 if __name__ == "__main__":
-    global temp_dir
     with TemporaryDirectory() as temp_dir:
+        translate_request = _build_translate_request(Path(temp_dir))
         with gr.Blocks(theme="Soft") as demo:
             with gr.Column():
                 title = gr.Markdown("## PDF Translator")

--- a/gui.py
+++ b/gui.py
@@ -7,17 +7,29 @@ import requests
 from pdf2image import convert_from_path
 from PIL import Image
 
+from utils.languages import DEFAULT_LANGUAGE_CODE, LANGUAGE_CONFIGS
+
 TRANSLATE_URL = "http://localhost:8765/translate_pdf/"
 CLEAR_TEMP_URL = "http://localhost:8765/clear_temp_dir/"
 
+LANGUAGE_OPTIONS = {
+    f"{config.label} ({config.code})": config.code
+    for config in sorted(LANGUAGE_CONFIGS.values(), key=lambda cfg: cfg.label)
+}
+DEFAULT_LANGUAGE_LABEL = next(
+    label for label, code in LANGUAGE_OPTIONS.items() if code == DEFAULT_LANGUAGE_CODE
+)
 
-def translate_request(file: Any) -> tuple[Path, list[Image.Image]]:
+
+def translate_request(file: Any, language_label: str) -> tuple[Path, list[Image.Image]]:
     """Sends a POST request to the translator server to translate a PDF.
 
     Parameters
     ----------
     file : Any
         the PDF to be translated.
+    language_label : str
+        Human-readable label of the selected target language.
 
     Returns
     -------
@@ -25,7 +37,18 @@ def translate_request(file: Any) -> tuple[Path, list[Image.Image]]:
         Path to the translated PDF and a list of images of the
         translated PDF.
     """
-    response = requests.post(TRANSLATE_URL, files={"input_pdf": open(file.name, "rb")})
+    if file is None:
+        raise ValueError("No PDF uploaded.")
+
+    if language_label not in LANGUAGE_OPTIONS:
+        raise ValueError("Unsupported language selection.")
+
+    with open(file.name, "rb") as input_pdf:
+        response = requests.post(
+            TRANSLATE_URL,
+            files={"input_pdf": input_pdf},
+            data={"target_language": LANGUAGE_OPTIONS[language_label]},
+        )
 
     if response.status_code == 200:
         with open(Path(temp_dir) / "translated.pdf", "wb") as f:
@@ -45,14 +68,19 @@ if __name__ == "__main__":
         with gr.Blocks(theme="Soft") as demo:
             with gr.Column():
                 title = gr.Markdown("## PDF Translator")
-                file = gr.File(label="ここにPDFをアップロード")
-                btn = gr.Button(value="翻訳")
-                translated_file = gr.File(label="翻訳されたPDF", file_types=[".pdf"])
-                pdf_images = gr.Gallery(label="翻訳されたPDFの画像")
+                file = gr.File(label="Upload PDF")
+                language = gr.Dropdown(
+                    choices=list(LANGUAGE_OPTIONS.keys()),
+                    value=DEFAULT_LANGUAGE_LABEL,
+                    label="Target language",
+                )
+                btn = gr.Button(value="Translate")
+                translated_file = gr.File(label="Translated PDF", file_types=[".pdf"])
+                pdf_images = gr.Gallery(label="Translated PDF preview")
 
                 btn.click(
                     translate_request,
-                    inputs=[file],
+                    inputs=[file, language],
                     outputs=[translated_file, pdf_images],
                 )
 

--- a/server/main.py
+++ b/server/main.py
@@ -2,15 +2,16 @@ import copy
 import re
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import PyPDF2
 import uvicorn
-from fastapi import FastAPI, File, UploadFile
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from pdf2image import convert_from_bytes, convert_from_path
 from PIL import Image, ImageDraw, ImageFont
@@ -20,7 +21,26 @@ from transformers import MarianMTModel, MarianTokenizer
 
 sys.path.append(str(Path(__file__).parent.parent))
 
-from utils import LayoutAnalyzer, OCRModel, fw_fill
+from utils import (
+    DEFAULT_LANGUAGE_CODE,
+    LANGUAGE_CONFIGS,
+    LayoutAnalyzer,
+    OCRModel,
+    normalize_language_code,
+)
+
+
+@dataclass
+class TranslationPipeline:
+    """Runtime resources for a translation target language."""
+
+    model: MarianMTModel
+    tokenizer: MarianTokenizer
+    config_code: str
+
+    @property
+    def config(self):
+        return LANGUAGE_CONFIGS[self.config_code]
 
 
 class InputPdf(BaseModel):
@@ -46,10 +66,8 @@ class TranslateApi:
         Layout model for detecting text blocks
     ocr_model: PaddleOCR
         OCR model for detecting text in the text blocks
-    translate_model: MarianMTModel
-        Translation model for translating text
-    translate_tokenizer: MarianTokenizer
-        Tokenizer for the translation model
+    translation_pipelines: Dict[str, TranslationPipeline]
+        Translation pipelines keyed by language code
     """
 
     DPI = 200
@@ -72,18 +90,26 @@ class TranslateApi:
         self.__load_models(model_root_dir)
         self.temp_dir = tempfile.TemporaryDirectory()
         self.temp_dir_name = Path(self.temp_dir.name)
+        self.translation_pipelines: Dict[str, TranslationPipeline] = {}
+        self.__load_translation_pipelines()
 
     def run(self):
         """Run the API server"""
         uvicorn.run(self.app, host="0.0.0.0", port=8765)
 
-    async def translate_pdf(self, input_pdf: UploadFile = File(...)) -> FileResponse:
+    async def translate_pdf(
+        self,
+        input_pdf: UploadFile = File(...),
+        target_language: str = Form(DEFAULT_LANGUAGE_CODE),
+    ) -> FileResponse:
         """API endpoint for translating PDF files.
 
         Parameters
         ----------
         input_pdf: UploadFile
             Input PDF file
+        target_language: str
+            Target language code for the translation.
 
         Returns
         -------
@@ -91,7 +117,8 @@ class TranslateApi:
             Translated PDF file
         """
         input_pdf_data = await input_pdf.read()
-        self._translate_pdf(input_pdf_data, self.temp_dir_name)
+        language_code = self.__validate_language(target_language)
+        self._translate_pdf(input_pdf_data, self.temp_dir_name, language_code)
 
         return FileResponse(
             self.temp_dir_name / "translated.pdf", media_type="application/pdf"
@@ -105,7 +132,7 @@ class TranslateApi:
         return {"message": "temp dir cleared"}
 
     def _translate_pdf(
-        self, pdf_path_or_bytes: Union[Path, bytes], output_dir: Path
+        self, pdf_path_or_bytes: Union[Path, bytes], output_dir: Path, language: str
     ) -> None:
         """Backend function for translating PDF files.
 
@@ -126,6 +153,8 @@ class TranslateApi:
             Path to the input PDF file or bytes of the input PDF file
         output_dir: Path
             Path to the output directory
+        language: str
+            Target language code for the translation
         """
         if isinstance(pdf_path_or_bytes, Path):
             pdf_images = convert_from_path(pdf_path_or_bytes, dpi=self.DPI)
@@ -140,6 +169,7 @@ class TranslateApi:
                 img, original_img, reached_references = self.__translate_one_page(
                     image=image,
                     reached_references=reached_references,
+                    language=language,
                 )
                 fig, ax = plt.subplots(1, 2, figsize=(20, 14))
                 ax[0].imshow(original_img)
@@ -187,22 +217,28 @@ class TranslateApi:
             model_root_dir=model_root_dir / "paddle-ocr", device=self.device
         )
 
-        self.translate_model = MarianMTModel.from_pretrained("staka/fugumt-en-ja").to(
-            self.device
-        )
-        self.translate_tokenizer = MarianTokenizer.from_pretrained("staka/fugumt-en-ja")
+    def __load_translation_pipelines(self):
+        """Load translation models for all supported languages."""
+
+        for code, config in LANGUAGE_CONFIGS.items():
+            model = MarianMTModel.from_pretrained(config.model_name).to(self.device)
+            tokenizer = MarianTokenizer.from_pretrained(config.tokenizer_name)
+            self.translation_pipelines[code] = TranslationPipeline(
+                model=model, tokenizer=tokenizer, config_code=code
+            )
 
     def __translate_one_page(
         self,
         image: Image.Image,
         reached_references: bool,
+        language: str,
     ) -> Tuple[np.ndarray, np.ndarray, bool]:
         """Translate one page of the PDF file.
 
         There are some heuristics to clean-up the results of translation:
             1. Remove newlines, tabs, brackets, slashes, and pipes
-            2. Reject the result if there are few Japanese characters
-            3. Skip the translation if the text block has only one line
+            2. Reject translations that do not match language-specific validators
+            3. Skip overly short translations to avoid noise
 
         Parameters
         ----------
@@ -210,6 +246,8 @@ class TranslateApi:
             Image of the page
         reached_references: bool
             Whether the references section has been reached.
+        language: str
+            Target language code for the translation.
 
         Returns
         -------
@@ -220,6 +258,8 @@ class TranslateApi:
         img = np.array(image, dtype=np.uint8)
         original_img = copy.deepcopy(img)
         result = self.layout_model(cv2.cvtColor(img, cv2.COLOR_RGB2BGR))
+        pipeline = self.translation_pipelines[language]
+
         for line in result:
             if line.type in ["text", "list"]:
                 ocr_results = list(map(lambda x: x[0], self.ocr_model(line.image)[1]))
@@ -227,24 +267,26 @@ class TranslateApi:
                 if len(ocr_results) > 1:
                     text = " ".join(ocr_results)
                     text = re.sub(r"\n|\t|\[|\]|\/|\|", " ", text)
-                    translated_text = self.__translate(text)
+                    translated_text = self.__translate(text, language)
 
-                    # if almost all characters in translated text are not japanese characters, skip
-                    if len(
-                        re.findall(
-                            r"[^\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\u3400-\u4DBF]",
-                            translated_text,
-                        )
-                    ) > 0.8 * len(translated_text):
+                    if not translated_text.strip():
                         print("skipped")
                         continue
 
-                    # if text is too short, skip
-                    if len(translated_text) < 20:
+                    if pipeline.config.validator and not pipeline.config.validator(
+                        translated_text
+                    ):
                         print("skipped")
                         continue
 
-                    processed_text = fw_fill(
+                    if (
+                        pipeline.config.min_length
+                        and len(translated_text.strip()) < pipeline.config.min_length
+                    ):
+                        print("skipped")
+                        continue
+
+                    processed_text = pipeline.config.wrap_text(
                         translated_text,
                         width=int((line.bbox[2] - line.bbox[0]) / (self.FONT_SIZE / 2))
                         - 1,
@@ -281,7 +323,7 @@ class TranslateApi:
 
         return img, original_img, reached_references
 
-    def __translate(self, text: str) -> str:
+    def __translate(self, text: str, language: str) -> str:
         """Translate text using the translation model.
 
         If the text is too long, it will be splited with
@@ -291,6 +333,8 @@ class TranslateApi:
         ----------
         text: str
             Text to be translated.
+        language: str
+            Target language code.
 
         Returns
         -------
@@ -300,19 +344,42 @@ class TranslateApi:
         texts = self.__split_text(text, 448)
 
         translated_texts = []
+        pipeline = self.translation_pipelines[language]
         for i, t in enumerate(texts):
-            inputs = self.translate_tokenizer(t, return_tensors="pt").input_ids.to(
+            inputs = pipeline.tokenizer(t, return_tensors="pt").input_ids.to(
                 self.device
             )
-            outputs = self.translate_model.generate(inputs, max_length=512)
-            res = self.translate_tokenizer.decode(outputs[0], skip_special_tokens=True)
+            outputs = pipeline.model.generate(
+                inputs, max_length=pipeline.config.max_length
+            )
+            res = pipeline.tokenizer.decode(outputs[0], skip_special_tokens=True)
 
-            # skip weird translations
-            if res.startswith("「この版"):
+            if pipeline.config.skip_prefixes and res.startswith(
+                pipeline.config.skip_prefixes
+            ):
                 continue
 
             translated_texts.append(res)
         return "".join(translated_texts)
+
+    def __validate_language(self, language: str) -> str:
+        """Validate a target language value provided by the API consumer."""
+
+        try:
+            normalized = normalize_language_code(language)
+        except ValueError as exc:  # pragma: no cover - FastAPI converts to JSON
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        if normalized not in self.translation_pipelines:
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "Requested language is supported but the corresponding "
+                    "translation pipeline is not loaded."
+                ),
+            )
+
+        return normalized
 
     def __split_text(self, text: str, text_limit: int = 448) -> List[str]:
         """Split text into chunks of sentences within text_limit.

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,24 @@
 from .textwrap_japanese import fw_fill, fw_wrap
 from .ocr_model import OCRModel
 from .layout_model import LayoutAnalyzer
+from .languages import (
+    LANGUAGE_CONFIGS,
+    DEFAULT_LANGUAGE_CODE,
+    get_language_config,
+    normalize_language_code,
+    supported_language_codes,
+    language_help_text,
+)
 
-__all__ = ["fw_fill", "fw_wrap", "OCRModel", "LayoutAnalyzer"]
+__all__ = [
+    "fw_fill",
+    "fw_wrap",
+    "OCRModel",
+    "LayoutAnalyzer",
+    "LANGUAGE_CONFIGS",
+    "DEFAULT_LANGUAGE_CODE",
+    "get_language_config",
+    "normalize_language_code",
+    "supported_language_codes",
+    "language_help_text",
+]

--- a/utils/languages.py
+++ b/utils/languages.py
@@ -1,0 +1,121 @@
+"""Language configuration utilities for Nok PDF Translator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, Tuple
+
+import re
+import textwrap
+
+from .textwrap_japanese import fw_fill
+
+
+@dataclass(frozen=True)
+class LanguageConfig:
+    """Configuration for a supported target language."""
+
+    code: str
+    label: str
+    model_name: str
+    tokenizer_name: str
+    wrap_text: Callable[[str, int], str]
+    min_length: int = 0
+    skip_prefixes: Tuple[str, ...] = ()
+    validator: Callable[[str], bool] | None = None
+    max_length: int = 512
+
+
+def _wrap_japanese(text: str, width: int) -> str:
+    """Wrap Japanese text respecting full-width characters."""
+
+    return fw_fill(text=text, width=max(width, 1))
+
+
+def _wrap_latin(text: str, width: int) -> str:
+    """Wrap Latin-based text."""
+
+    return textwrap.fill(text, width=max(width, 1))
+
+
+_JAPANESE_EXCLUSION_PATTERN = re.compile(
+    r"[^\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\u3400-\u4DBF\uFF66-\uFF9F]"
+)
+
+
+def _is_mostly_japanese(text: str) -> bool:
+    """Return True when the text is primarily composed of Japanese characters."""
+
+    stripped = text.strip()
+    if not stripped:
+        return False
+    non_japanese = len(_JAPANESE_EXCLUSION_PATTERN.findall(stripped))
+    return non_japanese <= 0.8 * len(stripped)
+
+
+LANGUAGE_CONFIGS: Dict[str, LanguageConfig] = {
+    "ja": LanguageConfig(
+        code="ja",
+        label="Japanese",
+        model_name="staka/fugumt-en-ja",
+        tokenizer_name="staka/fugumt-en-ja",
+        wrap_text=_wrap_japanese,
+        min_length=20,
+        skip_prefixes=("「この版",),
+        validator=_is_mostly_japanese,
+    ),
+    "pt-br": LanguageConfig(
+        code="pt-br",
+        label="Portuguese (Brazil)",
+        model_name="Helsinki-NLP/opus-mt-en-pt",
+        tokenizer_name="Helsinki-NLP/opus-mt-en-pt",
+        wrap_text=_wrap_latin,
+        min_length=5,
+    ),
+}
+
+DEFAULT_LANGUAGE_CODE = "ja"
+
+
+def get_language_config(code: str) -> LanguageConfig:
+    """Return the configuration for a target language."""
+
+    normalized_code = normalize_language_code(code)
+    return LANGUAGE_CONFIGS[normalized_code]
+
+
+def normalize_language_code(code: str) -> str:
+    """Normalize and validate a target language code."""
+
+    normalized = code.lower()
+    if normalized not in LANGUAGE_CONFIGS:
+        supported = ", ".join(sorted(LANGUAGE_CONFIGS))
+        raise ValueError(
+            f"Unsupported target language '{code}'. Supported languages: {supported}."
+        )
+    return normalized
+
+
+def supported_language_codes() -> Iterable[str]:
+    """Return an iterable with all supported language codes."""
+
+    return LANGUAGE_CONFIGS.keys()
+
+
+def language_help_text() -> str:
+    """Return a human readable description of the supported languages."""
+
+    return ", ".join(
+        f"{config.code} ({config.label})" for config in LANGUAGE_CONFIGS.values()
+    )
+
+
+__all__ = [
+    "LanguageConfig",
+    "LANGUAGE_CONFIGS",
+    "DEFAULT_LANGUAGE_CODE",
+    "get_language_config",
+    "normalize_language_code",
+    "supported_language_codes",
+    "language_help_text",
+]


### PR DESCRIPTION
## Summary
- add centralized language configuration to load Japanese and Brazilian Portuguese translation models
- expose target language selection across the API, CLI, GUI, and docker tooling
- document the new workflow and update dependencies for the multi-language pipeline

## Testing
- python -m compileall cli.py gui.py server utils

------
https://chatgpt.com/codex/tasks/task_e_68e5c6c35be8832d8886fbf23fbc305c

## Summary by Sourcery

Enable translation of PDFs into Japanese or Brazilian Portuguese by centralizing language configurations, dynamically loading per-language translation pipelines, and exposing a target language option across API, CLI, GUI, and Docker environments.

New Features:
- Add multi-language translation support with Brazilian Portuguese alongside Japanese
- Expose target language selection in the API, CLI, GUI, and Docker tooling
- Centralize language configurations and dynamically load translation pipelines for each supported language

Enhancements:
- Introduce a TranslationPipeline class for managing per-language models and tokenizers
- Validate and normalize requested language codes in API and CLI before processing

Documentation:
- Update README to document multi-language workflow, CLI options, and new Docker LANG environment variable